### PR TITLE
Fix backup directory format, it now ends with '.previous'

### DIFF
--- a/timedog
+++ b/timedog
@@ -192,7 +192,7 @@ chomp($tmpath = `tmutil machinedirectory`) if !$tmpath;
 die "No TimeMachine backups found" if !($tmpath && -d $tmpath);
 
 # Get all available backups
-my @backups=sort glob(qq("$tmpath/20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]"));
+my @backups=sort glob(qq("$tmpath/20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].previous"));
 map { s|^$tmpath/||; } @backups; 
 die "None or only one Time Machine backups found" if @backups <= 1;
 


### PR DESCRIPTION
Hi guys,

This fixes the #17 (and probably #18 too). At least I hope it fixes it because I only downloaded your tool yesterday and as I have Big Sur, it just showed me the message "None or only one Time Machine backups found at /usr/local/bin/timedog line 197."

My backups directory structure is the following:

```
2021-03-12-010326.interrupted <-- skipping these ".interrupted", not sure what's there
2021-03-12-174648.previous
2021-03-13-110439.interrupted  <-- skipping these ".interrupted", not sure what's there
2021-03-15-154701.previous
2021-03-15-175421.previous
```

With this simple fix I'm now able to see the diffs.