### PR TITLE
Fix backup directory format, allow both the old <datetime> and the new <datetime>.previous format

### DIFF
--- a/timedog
+++ b/timedog
@@ -192,7 +192,7 @@ chomp($tmpath = `tmutil machinedirectory`) if !$tmpath;
 die "No TimeMachine backups found" if !($tmpath && -d $tmpath);
 
 # Get all available backups
-my @backups=sort glob(qq("$tmpath/20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9].previous"));
+my @backups=sort glob(qq("$tmpath/20[0-9][0-9]-[0-9][0-9]-[0-9][0-9]-[0-9][0-9][0-9][0-9][0-9][0-9]{,.previous}"));
 map { s|^$tmpath/||; } @backups; 
 die "None or only one Time Machine backups found" if @backups <= 1;
 


### PR DESCRIPTION
This addresses the problems with the older TM directory structure, issues #17 and #18 