### PR TITLE
Remove -D option from help

### DIFF
--- a/timedog
+++ b/timedog
@@ -123,7 +123,7 @@ Use of tmutil to locate the time machine backup directory.
 =item Hayo Baan:
 
 Code rewrite & bug fixes.
-Additional help (-h), verbose (-v), sort (-S), display (-H), and backup directory (-D) options.
+Additional help (-h), verbose (-v), sort (-S), and display (-H) options.
 Documentation and help (perlpod).
 
 =back

--- a/timedog
+++ b/timedog
@@ -33,7 +33,7 @@ timedog - script to display the files backed up by time machine
 
   timedog -h
   timedog -t
-  timedog [-vlsHn] [-d depth] [-S sort] [-m limit] [-D backupdir] [timestamp]
+  timedog [-vlsHn] [-d depth] [-S sort] [-m limit] [timestamp]
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
`-D` was removed in 027a5fc but it's still listed in the help message